### PR TITLE
Fix: Implement double-hashing with domain separation

### DIFF
--- a/src/base/Roles/ManagerWithMerkleVerification.sol
+++ b/src/base/Roles/ManagerWithMerkleVerification.sol
@@ -279,7 +279,8 @@ contract ManagerWithMerkleVerification is Auth, IPausable {
     ) internal pure returns (bool) {
         bool valueNonZero = value > 0;
         bytes32 leaf =
-            keccak256(abi.encodePacked(decoderAndSanitizer, target, valueNonZero, selector, packedArgumentAddresses));
+
+            keccak256(abi.encode("BORING_VAULT_LEAF", keccak256(abi.encodePacked(decoderAndSanitizer, target, valueNonZero, selector, packedArgumentAddresses))));
         return MerkleProofLib.verify(proof, root, leaf);
     }
 }


### PR DESCRIPTION
Using abi.encodePacked without double-hashing, making it vulnerable to intermediate node attacks.